### PR TITLE
Add AssumeRole option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>connect-api</artifactId>
-			<version>0.11.0.2</version>
+			<version>1.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
@@ -36,6 +36,11 @@
 			<artifactId>testng</artifactId>
 			<version>6.9.10</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		  <groupId>com.amazonaws</groupId>
+		  <artifactId>aws-java-sdk-sts</artifactId>
+		  <version>1.11.265</version>		  
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
+++ b/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
@@ -11,6 +11,7 @@ import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 
 public class AmazonKinesisSinkConnector extends SinkConnector {
+	public static final String STS_SESSION_NAME_DEFAULT = "AmazonKinesisSink";
 
 	public static final String REGION = "region";
 
@@ -46,6 +47,10 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 	
 	public static final String SLEEP_CYCLES = "sleepCycles";
 
+	public static final String PRODUCER_ROLE = "producerRole";
+
+	public static final String STS_SESSION_NAME = "stsSessionName";
+
 	private String region;
 
 	private String streamName;
@@ -80,6 +85,10 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 	
 	private String sleepCycles;
 
+	private String producerRole;
+
+	private String stsSessionName;
+
 	@Override
 	public void start(Map<String, String> props) {
 		region = props.get(REGION);
@@ -99,6 +108,8 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 		outstandingRecordsThreshold = props.get(OUTSTANDING_RECORDS_THRESHOLD);
 		sleepPeriod = props.get(SLEEP_PERIOD);
 		sleepCycles = props.get(SLEEP_CYCLES);
+		producerRole = props.get(PRODUCER_ROLE);
+		stsSessionName = props.getOrDefault(STS_SESSION_NAME, STS_SESSION_NAME_DEFAULT);
 	}
 
 	@Override
@@ -198,6 +209,12 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 				config.put(SLEEP_CYCLES, sleepCycles);
 			else
 				config.put(SLEEP_CYCLES, "10");
+
+			if (producerRole != null)
+				config.put(PRODUCER_ROLE, producerRole);
+
+			if (stsSessionName != null)
+				config.put(STS_SESSION_NAME, stsSessionName);
 			
 			configs.add(config);
 

--- a/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkConnector.java
+++ b/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkConnector.java
@@ -11,6 +11,7 @@ import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 
 public class FirehoseSinkConnector extends SinkConnector {
+	public static final String STS_SESSION_NAME_DEFAULT = "AmazonKinesisSink";
 
 	public static final String DELIVERY_STREAM = "deliveryStream";
 	
@@ -22,6 +23,10 @@ public class FirehoseSinkConnector extends SinkConnector {
 	
 	public static final String BATCH_SIZE_IN_BYTES = "batchSizeInBytes";
 	
+	public static final String PRODUCER_ROLE = "producerRole";
+
+	public static final String STS_SESSION_NAME = "stsSessionName";
+
 	private String deliveryStream;
 	
 	private String region;
@@ -32,6 +37,10 @@ public class FirehoseSinkConnector extends SinkConnector {
 	
 	private String batchSizeInBytes; 
 	
+	private String producerRole;
+
+	private String stsSessionName;
+
 	private final String MAX_BATCH_SIZE = "500";
 	
 	private final String MAX_BATCH_SIZE_IN_BYTES = "3670016";
@@ -44,6 +53,8 @@ public class FirehoseSinkConnector extends SinkConnector {
 		batch = props.get(BATCH);	
 		batchSize = props.get(BATCH_SIZE);
 		batchSizeInBytes = props.get(BATCH_SIZE_IN_BYTES);
+		producerRole = props.get(PRODUCER_ROLE);
+		stsSessionName = props.getOrDefault(STS_SESSION_NAME, STS_SESSION_NAME_DEFAULT);
 	}
 
 	@Override
@@ -80,6 +91,12 @@ public class FirehoseSinkConnector extends SinkConnector {
 				config.put(BATCH_SIZE_IN_BYTES,  batchSizeInBytes);
 			else 
 				config.put(BATCH_SIZE_IN_BYTES, MAX_BATCH_SIZE_IN_BYTES);
+			
+			if (producerRole != null)
+				config.put(PRODUCER_ROLE, producerRole);
+
+			if (stsSessionName != null)
+				config.put(STS_SESSION_NAME, stsSessionName);
 			
 			configs.add(config);
 		}


### PR DESCRIPTION
Add the capability for Kinesis Sink to assume a role, allowing writing to streams in other accounts.

Some ugly duplication of code here to minimize intrusiveness of patch. In a subsequent iteration, should clean up common logic between Firehose and Kinesis Streams.