### PR TITLE
Use AmazonKinesisFirehoseClientBuilder

### DIFF
--- a/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkConnector.java
+++ b/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkConnector.java
@@ -14,6 +14,8 @@ public class FirehoseSinkConnector extends SinkConnector {
 
 	public static final String DELIVERY_STREAM = "deliveryStream";
 	
+	public static final String ENDPOINT = "endpoint";
+
 	public static final String REGION = "region";
 	
 	public static final String BATCH = "batch";
@@ -24,6 +26,8 @@ public class FirehoseSinkConnector extends SinkConnector {
 	
 	private String deliveryStream;
 	
+	private String endpoint;
+
 	private String region;
 	
 	private String batch;
@@ -40,6 +44,7 @@ public class FirehoseSinkConnector extends SinkConnector {
 	public void start(Map<String, String> props) {
 		
 		deliveryStream = props.get(DELIVERY_STREAM);
+		endpoint = props.get(ENDPOINT);
 		region = props.get(REGION);
 		batch = props.get(BATCH);	
 		batchSize = props.get(BATCH_SIZE);
@@ -65,6 +70,9 @@ public class FirehoseSinkConnector extends SinkConnector {
 			if (deliveryStream != null)
 				config.put(DELIVERY_STREAM, deliveryStream);
 			
+			if(endpoint != null)
+				config.put(ENDPOINT, endpoint);
+
 			if(region != null)
 				config.put(REGION, region);
 			

--- a/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkTask.java
+++ b/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkTask.java
@@ -11,9 +11,9 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseClient;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseClientBuilder;
 import com.amazonaws.services.kinesisfirehose.model.AmazonKinesisFirehoseException;
 import com.amazonaws.services.kinesisfirehose.model.DescribeDeliveryStreamRequest;
 import com.amazonaws.services.kinesisfirehose.model.DescribeDeliveryStreamResult;
@@ -31,7 +31,7 @@ public class FirehoseSinkTask extends SinkTask {
 
 	private String deliveryStreamName;
 
-	private AmazonKinesisFirehoseClient firehoseClient;
+	private AmazonKinesisFirehose firehoseClient;
 
 	private boolean batch;
 	
@@ -69,9 +69,14 @@ public class FirehoseSinkTask extends SinkTask {
 		
 		deliveryStreamName = props.get(FirehoseSinkConnector.DELIVERY_STREAM);
 
-		firehoseClient = new AmazonKinesisFirehoseClient(new DefaultAWSCredentialsProviderChain());
+		String endpoint = props.get(FirehoseSinkConnector.ENDPOINT);
 
-		firehoseClient.setRegion(RegionUtils.getRegion(props.get(FirehoseSinkConnector.REGION)));
+		String region = props.get(FirehoseSinkConnector.REGION);
+
+		firehoseClient = AmazonKinesisFirehoseClientBuilder
+				.standard()
+				.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+				.build();
 
 		// Validate delivery stream
 		validateDeliveryStream();


### PR DESCRIPTION
Use of the builder is preferred over using constructors of the client class.

Additionally, to allow this connector to work with firehose locally (e.g., localstack), we need to expose "endpoint" as configurable property.