### PR TITLE
Fix java.lang.ClassCastException thrown when pausing/resuming consumption

### DIFF
--- a/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkTask.java
+++ b/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkTask.java
@@ -154,7 +154,7 @@ public class AmazonKinesisSinkTask extends SinkTask {
 					while (producer.getOutstandingRecordsCount() > outstandingRecordsThreshold) {
 						try {
 							// Pausing further
-							sinkTaskContext.pause((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()])));
+							sinkTaskContext.pause((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()]));
 							pause = true;
 							Thread.sleep(sleepPeriod);
 							if (sleepCount++ > sleepCycles) {
@@ -184,7 +184,7 @@ public class AmazonKinesisSinkTask extends SinkTask {
 				while (kinesisProducer.getOutstandingRecordsCount() > outstandingRecordsThreshold) {
 					try {
 						// Pausing further
-						sinkTaskContext.pause((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()])));
+						sinkTaskContext.pause((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()]));
 						pause = true;
 						Thread.sleep(sleepPeriod);
 						if (sleepCount++ > sleepCycles) {
@@ -202,7 +202,7 @@ public class AmazonKinesisSinkTask extends SinkTask {
 					}
 				}
 				if (pause)
-					sinkTaskContext.resume((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()])));
+					sinkTaskContext.resume((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()]));
 				return true;
 			}
 		} else {

--- a/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkTask.java
+++ b/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkTask.java
@@ -154,7 +154,7 @@ public class AmazonKinesisSinkTask extends SinkTask {
 					while (producer.getOutstandingRecordsCount() > outstandingRecordsThreshold) {
 						try {
 							// Pausing further
-							sinkTaskContext.pause((TopicPartition[]) sinkTaskContext.assignment().toArray());
+							sinkTaskContext.pause((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()])));
 							pause = true;
 							Thread.sleep(sleepPeriod);
 							if (sleepCount++ > sleepCycles) {
@@ -172,7 +172,7 @@ public class AmazonKinesisSinkTask extends SinkTask {
 						}
 					}
 					if (pause)
-						sinkTaskContext.resume((TopicPartition[]) sinkTaskContext.assignment().toArray());
+						sinkTaskContext.resume((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()]));
 				});
 				return true;
 			} else {
@@ -184,7 +184,7 @@ public class AmazonKinesisSinkTask extends SinkTask {
 				while (kinesisProducer.getOutstandingRecordsCount() > outstandingRecordsThreshold) {
 					try {
 						// Pausing further
-						sinkTaskContext.pause((TopicPartition[]) sinkTaskContext.assignment().toArray());
+						sinkTaskContext.pause((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()])));
 						pause = true;
 						Thread.sleep(sleepPeriod);
 						if (sleepCount++ > sleepCycles) {
@@ -202,7 +202,7 @@ public class AmazonKinesisSinkTask extends SinkTask {
 					}
 				}
 				if (pause)
-					sinkTaskContext.resume((TopicPartition[]) sinkTaskContext.assignment().toArray());
+					sinkTaskContext.resume((TopicPartition[]) sinkTaskContext.assignment().toArray(new TopicPartition[sinkTaskContext.assignment().size()])));
 				return true;
 			}
 		} else {


### PR DESCRIPTION
Fixes following issue:

When the type of the list elements are not specified explicitly, `.toArray()` fails to cast the objects into `org.apache.kafka.common.PartitionTopic` and thus, throws
```
java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Lorg.apache.kafka.common.TopicPartition;
````