### PR TITLE
Add kinesis and cloudwatch endpoint to config, allow to disable cert validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ You can build the project by running "maven package" and it will build amazon-ki
 
 2.  If you don't specify aws user key nor aws secret key then connector will use [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) for authenitication. It looks for credentials in following order - environment variable, java system properties, credentials profile file at default location ( (~/.aws/credentials), credentials delievered through Amazon EC2 container service, and instance profile credentails delivered through Amazon EC2 metadata service. Make sure user has at least permission to list streams/delivery stream, describe streams/delivery stream and put records for stream/delivery stream.
 
+3. If you don't specify Kinesis host or CloudWatch host, the original one will be used.
+
 ### Running a Connector
 
 1.  Set up connector properties as shown in kafka-kinesis-firehose-connector.properties
@@ -41,6 +43,11 @@ You can build the project by running "maven package" and it will build amazon-ki
 | region| Specify region of your Kinesis Firehose | - |
 | awsKey | AWS user key.| - |
 | awsSecret | AWS user secret key.| - |
+| awsKinesisHost | AWS Kinesis host. (optional, must go with awsKinesisPort)| localhost |
+| awsKinesisPort | AWS Kinesis port. (optional, must go with awsKinesisHost)| 7700 |
+| awsCloudWatchHost | AWS CloudWatch host. (optional, must go with awsCloudWatchPort)| localhost |
+| awsCloudWatchPort | AWS CloudWatch port. (optional, must go with awsCloudWatchHost)| 7701 |
+| awsValidateCertificate | Should certificate be validated| true |
 | batch | Connector batches messages before sending to Kinesis Firehose (true/false) | true |
 | batchSize | Number of messages to be batched together. Firehose accepts at max 500 messages in one batch. | 500 |
 | batchSizeInBytes | Message size in bytes when batched together. Firehose accepts at max 4MB in one batch. | 3670016 |
@@ -52,6 +59,8 @@ You can build the project by running "maven package" and it will build amazon-ki
 1.  Make sure you create Kinesis stream in AWS Console/CLI/SDK – See more details [here](http://docs.aws.amazon.com/streams/latest/dev/learning-kinesis-module-one-create-stream.html).
 
 2.  If you don't specify aws user key nor aws secret key then connector will use [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) for authenitication. It looks for credentials in following order - environment variable, java system properties, credentials profile file at default location ( (~/.aws/credentials), credentials delievered through Amazon EC2 container service, and instance profile credentails delivered through Amazon EC2 metadata service. Make sure user has at least permission to list streams/delivery stream, describe streams/delivery stream and put records for stream/delivery stream.
+
+3. If you don't specify Kinesis host or CloudWatch host, the original one will be used.
 
 ### Running a Connector
 
@@ -77,6 +86,11 @@ You can build the project by running "maven package" and it will build amazon-ki
 | streamName | Kinesis Stream Name.| - |
 | awsKey | AWS user key.| - |
 | awsSecret | AWS user secret key.| - |
+| awsKinesisHost | AWS Kinesis host. (optional, must go with awsKinesisPort)| localhost |
+| awsKinesisPort | AWS Kinesis port. (optional, must go with awsKinesisHost)| 7700 |
+| awsCloudWatchHost | AWS CloudWatch host. (optional, must go with awsCloudWatchPort)| localhost |
+| awsCloudWatchPort | AWS CloudWatch port. (optional, must go with awsCloudWatchHost)| 7701 |
+| awsValidateCertificate | Should certificate be validated| true |
 | usePartitionAsHashKey | Using Kafka partition key as hash key for Kinesis streams.  | false |
 | maxBufferedTime | Maximum amount of time (milliseconds) a record may spend being buffered before it gets sent. Records may be sent sooner than this depending on the other buffering limits. Range: [100..... 9223372036854775807] | 15000 |
 | maxConnections | Maximum number of connections to open to the backend. HTTP requests are sent in parallel over multiple connections. Range: [1...256]. | 24 |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can build the project by running "maven package" and it will build amazon-ki
 
 1.  Make sure you create a delivery stream in AWS Console/CLI/SDK – See more details [here](http://docs.aws.amazon.com/firehose/latest/dev/basic-create.html) and configure destination.
 
-2.  Connector uses [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) for authenitication. It looks for credentials in following order - environment variable, java system properties, credentials profile file at default location ( (~/.aws/credentials), credentials delievered through Amazon EC2 container service, and instance profile credentails delivered through Amazon EC2 metadata service. Make sure user has at least permission to list streams/delivery stream, describe streams/delivery stream and put records for stream/delivery stream.
+2.  If you don't specify aws user key nor aws secret key then connector will use [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) for authenitication. It looks for credentials in following order - environment variable, java system properties, credentials profile file at default location ( (~/.aws/credentials), credentials delievered through Amazon EC2 container service, and instance profile credentails delivered through Amazon EC2 metadata service. Make sure user has at least permission to list streams/delivery stream, describe streams/delivery stream and put records for stream/delivery stream.
 
 ### Running a Connector
 
@@ -39,6 +39,8 @@ You can build the project by running "maven package" and it will build amazon-ki
 | connector.class      | Class for Amazon Kinesis Firehose Connector      |   com.amazon.kinesis.kafka.FirehoseSinkConnector |
 | topics | Kafka topics from where you want to consume messages. It can be single topic or comma separated list of topics      |   -  |
 | region| Specify region of your Kinesis Firehose | - |
+| awsKey | AWS user key.| - |
+| awsSecret | AWS user secret key.| - |
 | batch | Connector batches messages before sending to Kinesis Firehose (true/false) | true |
 | batchSize | Number of messages to be batched together. Firehose accepts at max 500 messages in one batch. | 500 |
 | batchSizeInBytes | Message size in bytes when batched together. Firehose accepts at max 4MB in one batch. | 3670016 |
@@ -49,7 +51,7 @@ You can build the project by running "maven package" and it will build amazon-ki
 
 1.  Make sure you create Kinesis stream in AWS Console/CLI/SDK – See more details [here](http://docs.aws.amazon.com/streams/latest/dev/learning-kinesis-module-one-create-stream.html).
 
-2.  Connector uses [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) for authenitication. It looks for credentials in following order - environment variable, java system properties, credentials profile file at default location ( (~/.aws/credentials), credentials delievered through Amazon EC2 container service, and instance profile credentails delivered through Amazon EC2 metadata service. Make sure user has at least permission to list streams/delivery stream, describe streams/delivery stream and put records for stream/delivery stream.
+2.  If you don't specify aws user key nor aws secret key then connector will use [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) for authenitication. It looks for credentials in following order - environment variable, java system properties, credentials profile file at default location ( (~/.aws/credentials), credentials delievered through Amazon EC2 container service, and instance profile credentails delivered through Amazon EC2 metadata service. Make sure user has at least permission to list streams/delivery stream, describe streams/delivery stream and put records for stream/delivery stream.
 
 ### Running a Connector
 
@@ -73,6 +75,8 @@ You can build the project by running "maven package" and it will build amazon-ki
 | topics | Kafka topics from where you want to consume messages. It can be single topic or comma separated list of topics      |   -  |
 | region| Specify region of your Kinesis Firehose | - |
 | streamName | Kinesis Stream Name.| - |
+| awsKey | AWS user key.| - |
+| awsSecret | AWS user secret key.| - |
 | usePartitionAsHashKey | Using Kafka partition key as hash key for Kinesis streams.  | false |
 | maxBufferedTime | Maximum amount of time (milliseconds) a record may spend being buffered before it gets sent. Records may be sent sooner than this depending on the other buffering limits. Range: [100..... 9223372036854775807] | 15000 |
 | maxConnections | Maximum number of connections to open to the backend. HTTP requests are sent in parallel over multiple connections. Range: [1...256]. | 24 |

--- a/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
+++ b/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
@@ -14,6 +14,10 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 
 	public static final String REGION = "region";
 
+	public static final String AWS_KEY = "awsKey";
+
+	public static final String AWS_SECRET = "awsSecret";
+
 	public static final String STREAM_NAME = "streamName";
 
 	public static final String MAX_BUFFERED_TIME = "maxBufferedTime";
@@ -80,6 +84,10 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 	
 	private String sleepCycles;
 
+	private String awsKey;
+
+	private String awsSecret;
+
 	@Override
 	public void start(Map<String, String> props) {
 		region = props.get(REGION);
@@ -99,6 +107,8 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 		outstandingRecordsThreshold = props.get(OUTSTANDING_RECORDS_THRESHOLD);
 		sleepPeriod = props.get(SLEEP_PERIOD);
 		sleepCycles = props.get(SLEEP_CYCLES);
+		awsKey = props.get(AWS_KEY);
+		awsSecret = props.get(AWS_SECRET);
 	}
 
 	@Override
@@ -198,6 +208,9 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 				config.put(SLEEP_CYCLES, sleepCycles);
 			else
 				config.put(SLEEP_CYCLES, "10");
+
+			config.put(AWS_KEY, awsKey);
+			config.put(AWS_SECRET, awsSecret);
 			
 			configs.add(config);
 

--- a/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
+++ b/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
@@ -14,10 +14,6 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 
 	public static final String REGION = "region";
 
-	public static final String AWS_KEY = "awsKey";
-
-	public static final String AWS_SECRET = "awsSecret";
-
 	public static final String STREAM_NAME = "streamName";
 
 	public static final String MAX_BUFFERED_TIME = "maxBufferedTime";
@@ -49,6 +45,15 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 	public static final String SLEEP_PERIOD = "sleepPeriod";
 	
 	public static final String SLEEP_CYCLES = "sleepCycles";
+
+	public static final String AWS_KEY = "awsKey";
+	public static final String AWS_SECRET = "awsSecret";
+
+	public static final String AWS_KINESIS_HOST = "awsKinesisHost";
+	public static final String AWS_KINESIS_PORT = "awsKinesisPort";
+	public static final String AWS_CLOUDWATCH_HOST = "awsCloudWatchHost";
+	public static final String AWS_CLOUDWATCH_PORT = "awsCloudWatchPort";
+	public static final String AWS_VALIDATE_CERTIFICATE = "awsValidateCertificate";
 
 	private String region;
 
@@ -85,8 +90,13 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 	private String sleepCycles;
 
 	private String awsKey;
-
 	private String awsSecret;
+
+	private String awsKinesisHost;
+	private String awsKinesisPort;
+	private String awsCloudWatchHost;
+	private String awsCloudWatchPort;
+	private String awsValidateCertificate;
 
 	@Override
 	public void start(Map<String, String> props) {
@@ -109,6 +119,11 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 		sleepCycles = props.get(SLEEP_CYCLES);
 		awsKey = props.get(AWS_KEY);
 		awsSecret = props.get(AWS_SECRET);
+		awsKinesisHost = props.get(AWS_KINESIS_HOST);
+		awsKinesisPort = props.get(AWS_KINESIS_PORT);
+		awsCloudWatchHost = props.get(AWS_CLOUDWATCH_HOST);
+		awsCloudWatchPort = props.get(AWS_CLOUDWATCH_PORT);
+		awsValidateCertificate = props.get(AWS_VALIDATE_CERTIFICATE);
 	}
 
 	@Override
@@ -208,6 +223,12 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 				config.put(SLEEP_CYCLES, sleepCycles);
 			else
 				config.put(SLEEP_CYCLES, "10");
+
+			config.put(AWS_KINESIS_HOST, awsKinesisHost);
+			config.put(AWS_KINESIS_PORT, awsKinesisPort);
+			config.put(AWS_CLOUDWATCH_HOST, awsCloudWatchHost);
+			config.put(AWS_CLOUDWATCH_PORT, awsCloudWatchPort);
+			config.put(AWS_VALIDATE_CERTIFICATE, awsValidateCertificate);
 
 			config.put(AWS_KEY, awsKey);
 			config.put(AWS_SECRET, awsSecret);

--- a/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkTask.java
+++ b/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkTask.java
@@ -35,6 +35,16 @@ public class AmazonKinesisSinkTask extends SinkTask {
 
 	private String awsSecret;
 
+	private String awsKinesisHost;
+
+	private Integer awsKinesisPort;
+
+	private String awsCloudWatchHost;
+
+	private Integer awsCloudWatchPort;
+
+	private Boolean awsValidateCertificate;
+
 	private int maxConnections;
 
 	private int rateLimit;
@@ -275,6 +285,19 @@ public class AmazonKinesisSinkTask extends SinkTask {
 
 		awsSecret = props.get(AmazonKinesisSinkConnector.AWS_SECRET);
 
+		awsKinesisHost = props.get(AmazonKinesisSinkConnector.AWS_KINESIS_HOST);
+
+		if (props.get(AmazonKinesisSinkConnector.AWS_KINESIS_PORT) != null)
+			awsKinesisPort = Integer.valueOf(props.get(AmazonKinesisSinkConnector.AWS_KINESIS_PORT));
+
+		awsCloudWatchHost = props.get(AmazonKinesisSinkConnector.AWS_CLOUDWATCH_HOST);
+
+		if (props.get(AmazonKinesisSinkConnector.AWS_CLOUDWATCH_PORT) != null)
+			awsCloudWatchPort = Integer.valueOf(props.get(AmazonKinesisSinkConnector.AWS_CLOUDWATCH_PORT));
+
+		if (props.get(AmazonKinesisSinkConnector.AWS_VALIDATE_CERTIFICATE) != null)
+			awsValidateCertificate = Boolean.valueOf(props.get(AmazonKinesisSinkConnector.AWS_VALIDATE_CERTIFICATE));
+
 		if (!singleKinesisProducerPerPartition)
 			kinesisProducer = getKinesisProducer();
 
@@ -310,9 +333,14 @@ public class AmazonKinesisSinkTask extends SinkTask {
 		}
 
 	}
-
 	private KinesisProducer getKinesisProducer() {
 		KinesisProducerConfiguration config = new KinesisProducerConfiguration();
+
+		setKinesisEnpointAndPortIfNotEmpty(config);
+		setCloudwatchEnpointAndPortIfNotEmpty(config);
+
+		setVerifyCertificateIfNotEmpty(config);
+
 		config.setRegion(regionName);
 		config.setCredentialsProvider(getCredentialProvider(awsKey, awsSecret));
 		config.setMaxConnections(maxConnections);
@@ -355,5 +383,26 @@ public class AmazonKinesisSinkTask extends SinkTask {
 		if(key != null && secret != null)
 			return new AWSStaticCredentialsProvider(new BasicAWSCredentials(key, secret));
 		else return new DefaultAWSCredentialsProviderChain();
+	}
+
+	private void setKinesisEnpointAndPortIfNotEmpty(KinesisProducerConfiguration config) {
+		if(awsKinesisHost != null && awsKinesisPort != null) {
+			config.setKinesisEndpoint(awsKinesisHost);
+			config.setKinesisPort(awsKinesisPort);
+			config.setVerifyCertificate(false);
+		}
+	}
+
+	private void setCloudwatchEnpointAndPortIfNotEmpty(KinesisProducerConfiguration config) {
+		if(awsCloudWatchHost != null && awsCloudWatchPort != null) {
+			config.setCloudwatchEndpoint(awsCloudWatchHost);
+			config.setCloudwatchPort(awsCloudWatchPort);
+		}
+	}
+
+	private void setVerifyCertificateIfNotEmpty(KinesisProducerConfiguration config) {
+		if (awsValidateCertificate != null){
+			config.setVerifyCertificate(awsValidateCertificate);
+		}
 	}
 }

--- a/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkTask.java
+++ b/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkTask.java
@@ -4,6 +4,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.DataException;
@@ -27,6 +30,10 @@ public class AmazonKinesisSinkTask extends SinkTask {
 	private String streamName;
 
 	private String regionName;
+
+	private String awsKey;
+
+	private String awsSecret;
 
 	private int maxConnections;
 
@@ -264,6 +271,10 @@ public class AmazonKinesisSinkTask extends SinkTask {
 
 		sleepCycles = Integer.parseInt(props.get(AmazonKinesisSinkConnector.SLEEP_CYCLES));
 
+		awsKey = props.get(AmazonKinesisSinkConnector.AWS_KEY);
+
+		awsSecret = props.get(AmazonKinesisSinkConnector.AWS_SECRET);
+
 		if (!singleKinesisProducerPerPartition)
 			kinesisProducer = getKinesisProducer();
 
@@ -303,7 +314,7 @@ public class AmazonKinesisSinkTask extends SinkTask {
 	private KinesisProducer getKinesisProducer() {
 		KinesisProducerConfiguration config = new KinesisProducerConfiguration();
 		config.setRegion(regionName);
-		config.setCredentialsProvider(new DefaultAWSCredentialsProviderChain());
+		config.setCredentialsProvider(getCredentialProvider(awsKey, awsSecret));
 		config.setMaxConnections(maxConnections);
 
 		config.setAggregationEnabled(aggregration);
@@ -340,4 +351,9 @@ public class AmazonKinesisSinkTask extends SinkTask {
 
 	}
 
+	private AWSCredentialsProvider getCredentialProvider(String key, String secret) {
+		if(key != null && secret != null)
+			return new AWSStaticCredentialsProvider(new BasicAWSCredentials(key, secret));
+		else return new DefaultAWSCredentialsProviderChain();
+	}
 }


### PR DESCRIPTION
### Description:
Add kinesis and cloudwatch endpoint to config, allow to disable cert validation

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to Kinesis-Kafka Connector.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [-] Is there a ISSUE associated with this PR?
- [-] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [+] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [+] Is your initial contribution a single, squashed commit?

### For code changes:
- [+] Have you ensured that the full suite of tests is executed via `mvn clean install` at the project's root folder?
- [-] Have you written or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the LICENSE file?
- [-] If applicable, have you added the LICENSE header to new files?

### For documentation related changes:
- [+] Have you ensured that format looks appropriate for the output in which it is rendered?
