### PR TITLE
ISSUE-40 Support for China region

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,5 @@ You can build the project by running "maven package" and it will build amazon-ki
 | metricsLevel | Controls the number of metrics that are uploaded to CloudWatch. Expected pattern: none/summary/detailed | none |
 | metricsGranuality | Controls the granularity of metrics that are uploaded to CloudWatch. Greater granularity produces more metrics. Expected pattern: global/stream/shard. |  global |
 | metricsNameSpace | The namespace to upload metrics under. | KinesisProducer |
-| aggregration | With aggregation, multiple user records are packed into a single KinesisRecord. If disabled, each user record is sent in its own KinesisRecord.| true
+| aggregration | With aggregation, multiple user records are packed into a single KinesisRecord. If disabled, each user record is sent in its own KinesisRecord.| true |
+| appendLineBreak | If Enabled, a line break will be append to each record in Kafka message before inject into Kinesis. It is useful if records are saved to S3 using Kinesis Firehose, and use Apache HIVE for further processing | false |

--- a/config/kinesis-streams-kafka-connector.properties
+++ b/config/kinesis-streams-kafka-connector.properties
@@ -26,3 +26,5 @@ metricsLevel=detailed
 metricsGranuality=shard
 metricsNameSpace=KafkaKinesisStreamsConnector
 aggregration=true
+# Append Line break "\n" to every record
+appendLineBreak=false

--- a/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
+++ b/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
@@ -33,18 +33,20 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 	public static final String AGGREGRATION_ENABLED = "aggregration";
 
 	public static final String USE_PARTITION_AS_HASH_KEY = "usePartitionAsHashKey";
-	
+
 	public static final String FLUSH_SYNC = "flushSync";
-	
+
 	public static final String SINGLE_KINESIS_PRODUCER_PER_PARTITION = "singleKinesisProducerPerPartition";
-	
-	public static final String PAUSE_CONSUMPTION = "pauseConsumption"; 
-	
+
+	public static final String PAUSE_CONSUMPTION = "pauseConsumption";
+
 	public static final String OUTSTANDING_RECORDS_THRESHOLD = "outstandingRecordsThreshold";
-	
+
 	public static final String SLEEP_PERIOD = "sleepPeriod";
-	
+
 	public static final String SLEEP_CYCLES = "sleepCycles";
+
+	public static final String APPEND_LINE_BREAK = "appendLineBreak";
 
 	private String region;
 
@@ -67,18 +69,20 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 	private String aggregration;
 
 	private String usePartitionAsHashKey;
-	
+
 	private String flushSync;
-	
-	private String singleKinesisProducerPerPartition; 
-	
+
+	private String singleKinesisProducerPerPartition;
+
 	private String pauseConsumption;
-	
+
 	private String outstandingRecordsThreshold;
-	
+
 	private String sleepPeriod;
-	
+
 	private String sleepCycles;
+
+	private String appendLineBreak;
 
 	@Override
 	public void start(Map<String, String> props) {
@@ -99,6 +103,7 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 		outstandingRecordsThreshold = props.get(OUTSTANDING_RECORDS_THRESHOLD);
 		sleepPeriod = props.get(SLEEP_PERIOD);
 		sleepCycles = props.get(SLEEP_CYCLES);
+		appendLineBreak = props.get(APPEND_LINE_BREAK);
 	}
 
 	@Override
@@ -168,37 +173,42 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 				config.put(USE_PARTITION_AS_HASH_KEY, usePartitionAsHashKey);
 			else
 				config.put(USE_PARTITION_AS_HASH_KEY, "false");
-			
+
 			if(flushSync != null)
 				config.put(FLUSH_SYNC, flushSync);
 			else
 				config.put(FLUSH_SYNC, "true");
-			
+
 			if(singleKinesisProducerPerPartition != null)
 				config.put(SINGLE_KINESIS_PRODUCER_PER_PARTITION, singleKinesisProducerPerPartition);
 			else
 				config.put(SINGLE_KINESIS_PRODUCER_PER_PARTITION, "false");
-			
+
 			if(pauseConsumption != null)
 				config.put(PAUSE_CONSUMPTION, pauseConsumption);
 			else
 				config.put(PAUSE_CONSUMPTION, "true");
-			
+
 			if(outstandingRecordsThreshold != null)
 				config.put(OUTSTANDING_RECORDS_THRESHOLD, outstandingRecordsThreshold);
 			else
 				config.put(OUTSTANDING_RECORDS_THRESHOLD, "500000");
-			
+
 			if(sleepPeriod != null)
 				config.put(SLEEP_PERIOD, sleepPeriod);
 			else
 				config.put(SLEEP_PERIOD, "1000");
-			
+
 			if(sleepCycles != null)
 				config.put(SLEEP_CYCLES, sleepCycles);
 			else
 				config.put(SLEEP_CYCLES, "10");
-			
+
+			if (appendLineBreak != null)
+				config.put(APPEND_LINE_BREAK, appendLineBreak);
+			else
+				config.put(APPEND_LINE_BREAK, "false");
+
 			configs.add(config);
 
 		}


### PR DESCRIPTION
### Description:
1. Add option to append line break to each record from Kafka. Add an option `appendLineBreak`, by enabling this option, the connector will append `\n` to each record before injecting into Kinesis Datastreams.
2. Add support for China region. Now if the connector is configured to be used in AWS China region, it will change to the correct Kinesis/Firehose endpoint. 

### Issue Reference URL

https://github.com/awslabs/kinesis-kafka-connector/issues/40

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to Kinesis-Kafka Connector.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a ISSUE associated with this PR?
- [x] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn clean install` at the project's root folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you added the LICENSE header to new files?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?
