### PR TITLE
ISSUE-44 Allow a task to run with an IAM role and external-id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ You can build the project by running "maven package" and it will build amazon-ki
 | connector.class      | Class for Amazon Kinesis Firehose Connector      |   com.amazon.kinesis.kafka.FirehoseSinkConnector |
 | topics | Kafka topics from where you want to consume messages. It can be single topic or comma separated list of topics      |   -  |
 | region| Specify region of your Kinesis Firehose | - |
+| kinesisEndpoint| Alternate Kinesis endpoint, such as for a NAT gateway (optional) | - |
+| roleARN | IAM Role ARN to assume (optional)| - |
+| roleSessionName | IAM Role session-name to be logged (optional)| - |
+| roleExternalID | IAM Role external-id (optional)| - |
+| roleDurationSeconds | Duration of STS assumeRole session (optional)| - |
 | batch | Connector batches messages before sending to Kinesis Firehose (true/false) | true |
 | batchSize | Number of messages to be batched together. Firehose accepts at max 500 messages in one batch. | 500 |
 | batchSizeInBytes | Message size in bytes when batched together. Firehose accepts at max 4MB in one batch. | 3670016 |
@@ -72,7 +77,12 @@ You can build the project by running "maven package" and it will build amazon-ki
 | connector.class      | Class for Amazon Kinesis Stream Connector      |   com.amazon.kinesis.kafka.AmazonKinesisSinkConnector |
 | topics | Kafka topics from where you want to consume messages. It can be single topic or comma separated list of topics      |   -  |
 | region| Specify region of your Kinesis Firehose | - |
+| kinesisEndpoint| Alternate Kinesis endpoint, such as for a NAT gateway (optional) | - |
 | streamName | Kinesis Stream Name.| - |
+| roleARN | IAM Role ARN to assume (optional)| - |
+| roleSessionName | IAM Role session-name to be logged (optional)| - |
+| roleExternalID | IAM Role external-id (optional)| - |
+| roleDurationSeconds | Duration of STS assumeRole session (optional)| - |
 | usePartitionAsHashKey | Using Kafka partition key as hash key for Kinesis streams.  | false |
 | maxBufferedTime | Maximum amount of time (milliseconds) a record may spend being buffered before it gets sent. Records may be sent sooner than this depending on the other buffering limits. Range: [100..... 9223372036854775807] | 15000 |
 | maxConnections | Maximum number of connections to open to the backend. HTTP requests are sent in parallel over multiple connections. Range: [1...256]. | 24 |

--- a/pom.xml
+++ b/pom.xml
@@ -19,22 +19,22 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>connect-api</artifactId>
-			<version>2.4.1</version>
+			<version>2.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-client</artifactId>
-			<version>1.13.3</version>
+			<version>1.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-sts</artifactId>
-			<version>1.11.759</version>
+			<version>1.11.861</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-producer</artifactId>
-			<version>0.14.0</version>
+			<version>0.14.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,14 @@
 				<version>2.3</version>
 				<configuration>
 					<createDependencyReducedPom>false</createDependencyReducedPom>
+	                <filters>
+	                    <filter>
+	                        <artifact>*:*</artifact>
+	                        <excludes>
+	                            <exclude>module-info.class</exclude>
+	                        </excludes>
+	                    </filter>
+                    </filters>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -19,17 +19,22 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>connect-api</artifactId>
-			<version>0.11.0.2</version>
+			<version>2.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-client</artifactId>
-			<version>1.7.3</version>
+			<version>1.13.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sts</artifactId>
+			<version>1.11.759</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-producer</artifactId>
-			<version>0.12.8</version>
+			<version>0.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.testng</groupId>

--- a/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
+++ b/src/main/java/com/amazon/kinesis/kafka/AmazonKinesisSinkConnector.java
@@ -46,9 +46,29 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 	
 	public static final String SLEEP_CYCLES = "sleepCycles";
 
+	public static final String ROLE_ARN = "roleARN";
+
+	public static final String ROLE_SESSION_NAME = "roleSessionName";
+
+	public static final String ROLE_EXTERNAL_ID = "roleExternalID";
+
+	public static final String ROLE_DURATION_SECONDS = "roleDurationSeconds";
+
+	public static final String KINESIS_ENDPOINT = "kinesisEndpoint";
+
 	private String region;
 
 	private String streamName;
+
+	private String roleARN;
+
+	private String roleSessionName;
+
+	private String roleExternalID;
+
+	private String roleDurationSeconds;
+
+	private String kinesisEndpoint;
 
 	private String maxBufferedTime;
 
@@ -84,6 +104,11 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 	public void start(Map<String, String> props) {
 		region = props.get(REGION);
 		streamName = props.get(STREAM_NAME);
+		roleARN = props.get(ROLE_ARN);
+		roleSessionName = props.get(ROLE_SESSION_NAME);
+		roleExternalID = props.get(ROLE_EXTERNAL_ID);
+		roleDurationSeconds = props.get(ROLE_DURATION_SECONDS);
+		kinesisEndpoint = props.get(KINESIS_ENDPOINT);
 		maxBufferedTime = props.get(MAX_BUFFERED_TIME);
 		maxConnections = props.get(MAX_CONNECTIONS);
 		rateLimit = props.get(RATE_LIMIT);
@@ -122,6 +147,23 @@ public class AmazonKinesisSinkConnector extends SinkConnector {
 
 			if (region != null)
 				config.put(REGION, region);
+
+			if (roleARN != null)
+				config.put(ROLE_ARN, roleARN);
+
+			if (roleSessionName != null)
+				config.put(ROLE_SESSION_NAME, roleSessionName);
+
+			if (roleExternalID != null)
+				config.put(ROLE_EXTERNAL_ID, roleExternalID);
+
+			if (roleDurationSeconds != null)
+				config.put(ROLE_DURATION_SECONDS, roleDurationSeconds);
+			else
+				config.put(ROLE_DURATION_SECONDS, "3600");
+
+			if (kinesisEndpoint != null)
+				config.put(KINESIS_ENDPOINT, kinesisEndpoint);
 
 			if (maxBufferedTime != null)
 				config.put(MAX_BUFFERED_TIME, maxBufferedTime);

--- a/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkConnector.java
+++ b/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkConnector.java
@@ -21,7 +21,17 @@ public class FirehoseSinkConnector extends SinkConnector {
 	public static final String BATCH_SIZE = "batchSize";
 	
 	public static final String BATCH_SIZE_IN_BYTES = "batchSizeInBytes";
-	
+
+	public static final String ROLE_ARN = "roleARN";
+
+	public static final String ROLE_SESSION_NAME = "roleSessionName";
+
+	public static final String ROLE_EXTERNAL_ID = "roleExternalID";
+
+	public static final String ROLE_DURATION_SECONDS = "roleDurationSeconds";
+
+	public static final String KINESIS_ENDPOINT = "kinesisEndpoint";
+
 	private String deliveryStream;
 	
 	private String region;
@@ -30,8 +40,18 @@ public class FirehoseSinkConnector extends SinkConnector {
 	
 	private String batchSize;
 	
-	private String batchSizeInBytes; 
-	
+	private String batchSizeInBytes;
+
+	private String roleARN;
+
+	private String roleSessionName;
+
+	private String roleExternalID;
+
+	private String roleDurationSeconds;
+
+	private String kinesisEndpoint;
+
 	private final String MAX_BATCH_SIZE = "500";
 	
 	private final String MAX_BATCH_SIZE_IN_BYTES = "3670016";
@@ -44,6 +64,11 @@ public class FirehoseSinkConnector extends SinkConnector {
 		batch = props.get(BATCH);	
 		batchSize = props.get(BATCH_SIZE);
 		batchSizeInBytes = props.get(BATCH_SIZE_IN_BYTES);
+		roleARN = props.get(ROLE_ARN);
+		roleSessionName = props.get(ROLE_SESSION_NAME);
+		roleExternalID = props.get(ROLE_EXTERNAL_ID);
+		roleDurationSeconds = props.get(ROLE_DURATION_SECONDS);
+		kinesisEndpoint = props.get(KINESIS_ENDPOINT);
 	}
 
 	@Override
@@ -80,7 +105,24 @@ public class FirehoseSinkConnector extends SinkConnector {
 				config.put(BATCH_SIZE_IN_BYTES,  batchSizeInBytes);
 			else 
 				config.put(BATCH_SIZE_IN_BYTES, MAX_BATCH_SIZE_IN_BYTES);
-			
+
+			if (roleARN != null)
+				config.put(ROLE_ARN, roleARN);
+
+			if (roleSessionName != null)
+				config.put(ROLE_SESSION_NAME, roleSessionName);
+
+			if (roleExternalID != null)
+				config.put(ROLE_EXTERNAL_ID, roleExternalID);
+
+			if (roleDurationSeconds != null)
+				config.put(ROLE_DURATION_SECONDS, roleDurationSeconds);
+			else
+				config.put(ROLE_DURATION_SECONDS, "3600");
+
+			if (kinesisEndpoint != null)
+				config.put(KINESIS_ENDPOINT, kinesisEndpoint);
+
 			configs.add(config);
 		}
 		return configs;

--- a/src/main/java/com/amazon/kinesis/kafka/IAMUtility.java
+++ b/src/main/java/com/amazon/kinesis/kafka/IAMUtility.java
@@ -1,17 +1,17 @@
-/**
- Copyright 2020 Scott Kidder
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+/*
+ * Copyright 2020 Scott Kidder
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.kinesis.kafka;

--- a/src/main/java/com/amazon/kinesis/kafka/IAMUtility.java
+++ b/src/main/java/com/amazon/kinesis/kafka/IAMUtility.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.amazon.kinesis.kafka;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -7,7 +26,27 @@ import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.util.StringUtils;
 
+/**
+ * IAMUtility offers convenience functions for creating AWS IAM credential providers.
+ *
+ */
 public class IAMUtility {
+
+    /**
+     * Create an IAM credentials provider.
+     *
+     * If a role ARN is provided, then an STS assume-role credentials provider is created. The
+     * provider will automatically renew the assume-role session as needed.
+     *
+     * If the role ARN is empty or null, then the default AWS credentials provider is returned.
+     *
+     * @param regionName AWS region-name (must be non-empty when using assume-role).
+     * @param roleARN IAM role ARN to assume (if non-empty then STS assume-role provider is returned).
+     * @param roleExternalID Optional external-id string to scope access within AWS account.
+     * @param roleSessionName Optional role session-name used for logging & debugging.
+     * @param roleDurationSeconds Duration of the STS assume-role session (auto-renewed on expiration).
+     * @return AWS credentials provider
+     */
     static AWSCredentialsProvider createCredentials(String regionName, String roleARN, String roleExternalID, String roleSessionName, int roleDurationSeconds) {
         if (StringUtils.isNullOrEmpty(roleARN))
             return new DefaultAWSCredentialsProviderChain();

--- a/src/main/java/com/amazon/kinesis/kafka/IAMUtility.java
+++ b/src/main/java/com/amazon/kinesis/kafka/IAMUtility.java
@@ -1,20 +1,17 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ Copyright 2020 Scott Kidder
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
  */
 
 package com.amazon.kinesis.kafka;

--- a/src/main/java/com/amazon/kinesis/kafka/IAMUtility.java
+++ b/src/main/java/com/amazon/kinesis/kafka/IAMUtility.java
@@ -1,0 +1,29 @@
+package com.amazon.kinesis.kafka;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.util.StringUtils;
+
+public class IAMUtility {
+    static AWSCredentialsProvider createCredentials(String regionName, String roleARN, String roleExternalID, String roleSessionName, int roleDurationSeconds) {
+        if (StringUtils.isNullOrEmpty(roleARN))
+            return new DefaultAWSCredentialsProviderChain();
+
+        // Use STS to assume a role if one was given
+        final AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
+                .withCredentials(new DefaultAWSCredentialsProviderChain())
+                .withRegion(regionName)
+                .build();
+
+        STSAssumeRoleSessionCredentialsProvider.Builder providerBuilder = new STSAssumeRoleSessionCredentialsProvider.Builder(roleARN, roleSessionName).withStsClient(stsClient);
+        if (!StringUtils.isNullOrEmpty(roleExternalID))
+            providerBuilder = providerBuilder.withExternalId(roleExternalID);
+        if (roleDurationSeconds > 0)
+            providerBuilder = providerBuilder.withRoleSessionDurationSeconds(roleDurationSeconds);
+
+        return providerBuilder.build();
+    }
+}


### PR DESCRIPTION
### Description:
Allow a Kinesis or Kinesis Firehose task to assume an IAM role with optional external-id. This is especially useful when exporting data from Kafka topics to Kinesis streams owned by another AWS account or organization.

Also, upgrade the Kafka Connect API and AWS dependencies to latest stable.

### Issue Reference URL

https://github.com/awslabs/kinesis-kafka-connector/issues/44

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to Kinesis-Kafka Connector.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a ISSUE associated with this PR?
- [X] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn clean install` at the project's root folder?
- [X] Have you written or updated unit tests to verify your changes?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [X] If applicable, have you updated the LICENSE file?
- [X] If applicable, have you added the LICENSE header to new files?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?
