### PR TITLE
Issue 60 vpc endpoint bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can build the project by running "maven package" and it will build amazon-ki
 | name     | User defined name of connector  | - |
 | connector.class      | Class for Amazon Kinesis Stream Connector      |   com.amazon.kinesis.kafka.AmazonKinesisSinkConnector |
 | topics | Kafka topics from where you want to consume messages. It can be single topic or comma separated list of topics      |   -  |
-| region| Specify region of your Kinesis Firehose | - |
+| region| Specify region of your Kinesis Firehose. Note, this parameter is mandatory, if `kinesisEndpoint` is provided | - |
 | kinesisEndpoint| Alternate Kinesis endpoint, such as for a NAT gateway (optional) | - |
 | streamName | Kinesis Stream Name.| - |
 | roleARN | IAM Role ARN to assume (optional)| - |

--- a/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkTask.java
+++ b/src/main/java/com/amazon/kinesis/kafka/FirehoseSinkTask.java
@@ -112,9 +112,6 @@ public class FirehoseSinkTask extends SinkTask {
 		firehoseClient = builder.build();
 		
 
-//		if (!StringUtils.isNullOrEmpty(kinesisEndpoint))
-//			firehoseClient.setEndpoint(kinesisEndpoint);
-
 		// Validate delivery stream
 		validateDeliveryStream();
 	}


### PR DESCRIPTION
### Description:
Fixing a bug in setting VPC Endpoint for Firehose.

Following configuration of endpoint and regions are recommended:

- if no `kinesisEndpoint` specified in the config, `region` is optional. If not specified, current region will be used.
- if `kinesisEndpoint` is specified, explicit property for `region` is mandatory

### Issue Reference URL

#60 

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to Kinesis-Kafka Connector.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a ISSUE associated with this PR?
- [x] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn clean install` at the project's root folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you added the LICENSE header to new files?
