### PR TITLE
ISSUE-74 updating junits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.amazonaws</groupId>
@@ -12,14 +12,22 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+		<junit.jupiter.version>5.9.1</junit.jupiter.version>
+		<junit.platform.version>1.8.2</junit.platform.version>
+		<slf4j.version>1.7.32</slf4j.version>
+		<kafka.version>2.8.0</kafka.version>
 	</properties>
-
+	
 	<dependencies>
 
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>connect-api</artifactId>
-			<version>2.5.1</version>
+			<version>2.7.1</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
@@ -37,16 +45,53 @@
 			<version>0.14.1</version>
 		</dependency>
 		<dependency>
-			<groupId>org.testng</groupId>
-			<artifactId>testng</artifactId>
-			<version>6.9.10</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-dependencies</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/libs</outputDirectory>
+							<overWriteReleases>false</overWriteReleases>
+							<overWriteSnapshots>false</overWriteSnapshots>
+							<overWriteIfNewer>true</overWriteIfNewer>
+							<includeScope>runtime</includeScope>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<finalName>kinesis-kafka-connector</finalName>
+					<archive>
+						<manifest>
+							<addClasspath>false</addClasspath>
+						</manifest>
+						<!--
+						<manifestEntries>
+							<Class-Path>libs/</Class-Path>
+						</manifestEntries>
+						-->
+					</archive>
+				</configuration>
+			</plugin>
+			<!--plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>2.3</version>
@@ -69,8 +114,10 @@
 						</goals>
 						<configuration>
 							<artifactSet>
+			 -->
 								<!-- Excluding directories that are available in Kafka to avoid version 
 								     									conflict -->
+			<!--
 								<excludes>
 									<exclude>org.apache.kafka:*</exclude>
 									<exclude>com.fasterxml.jackson.annotation:*</exclude>
@@ -93,6 +140,7 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+			-->
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,9 @@
 						<manifest>
 							<addClasspath>false</addClasspath>
 						</manifest>
-						<!--
 						<manifestEntries>
 							<Class-Path>libs/</Class-Path>
 						</manifestEntries>
-						-->
 					</archive>
 				</configuration>
 			</plugin>

--- a/src/test/java/com/amazon/kinesis/kafka/DataUtilityTest.java
+++ b/src/test/java/com/amazon/kinesis/kafka/DataUtilityTest.java
@@ -1,11 +1,12 @@
 package com.amazon.kinesis.kafka;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.testng.annotations.Test;
-import org.testng.Assert;
+import org.junit.jupiter.api.Test;
 
 public class DataUtilityTest {
 	
@@ -16,7 +17,7 @@ public class DataUtilityTest {
 		ByteBuffer actual = DataUtility.parseValue(schema, (byte) 2);
 		ByteBuffer expected = ByteBuffer.allocate(1).put((byte) 2);
 		
-		Assert.assertTrue(actual.equals(expected));
+		assertTrue(actual.equals(expected));
 		
 	}
 	
@@ -27,7 +28,7 @@ public class DataUtilityTest {
 		ByteBuffer actual = DataUtility.parseValue(schema, (short) 2);
 		ByteBuffer expected = ByteBuffer.allocate(2).putShort((short) 2);
 		
-		Assert.assertTrue(actual.equals(expected));
+		assertTrue(actual.equals(expected));
 	
 	}
 	
@@ -38,7 +39,7 @@ public class DataUtilityTest {
 		ByteBuffer actualInt32 = DataUtility.parseValue(schemaInt32, (int) 2);
 		ByteBuffer expectedInt32 = ByteBuffer.allocate(4).putInt( (int) 2);
 		
-		Assert.assertTrue(actualInt32.equals(expectedInt32));
+		assertTrue(actualInt32.equals(expectedInt32));
 	}
 	
 	@Test
@@ -48,7 +49,7 @@ public class DataUtilityTest {
 		ByteBuffer actual = DataUtility.parseValue(schema, (long) 2);
 		ByteBuffer expected = ByteBuffer.allocate(8).putLong( (long) 2);
 		
-		Assert.assertTrue(actual.equals(expected));
+		assertTrue(actual.equals(expected));
 		
 	}
 	
@@ -59,7 +60,7 @@ public class DataUtilityTest {
 		ByteBuffer actual = DataUtility.parseValue(schema, (float) 2);
 		ByteBuffer expected = ByteBuffer.allocate(4).putFloat((float) 2);
 		
-		Assert.assertTrue(actual.equals(expected));
+		assertTrue(actual.equals(expected));
 		
 	}
 	
@@ -70,7 +71,7 @@ public class DataUtilityTest {
 		ByteBuffer actual = DataUtility.parseValue(schema, (double) 2);
 		ByteBuffer expected = ByteBuffer.allocate(8).putDouble((double) 2);
 		
-		Assert.assertTrue(actual.equals(expected));
+		assertTrue(actual.equals(expected));
 		
 	}
 	
@@ -81,7 +82,7 @@ public class DataUtilityTest {
 		ByteBuffer actual = DataUtility.parseValue(schema, (boolean) true);
 		ByteBuffer expected = ByteBuffer.allocate(1).put( (byte) 1);
 		
-		Assert.assertTrue(actual.equals(expected));
+		assertTrue(actual.equals(expected));
 	}
 	
 	@Test
@@ -97,7 +98,7 @@ public class DataUtilityTest {
 			e.printStackTrace();
 		}
 		
-		Assert.assertTrue(actual.equals(expected));
+		assertTrue(actual.equals(expected));
 
 	}
 	
@@ -111,7 +112,7 @@ public class DataUtilityTest {
 		ByteBuffer actual = DataUtility.parseValue(schema, arrayOfInt8);
 		ByteBuffer expected = ByteBuffer.allocate(4).put((byte) 1).put( (byte) 2).put( (byte) 3).put( (byte) 4);
 		
-		Assert.assertTrue(actual.equals(expected));
+		assertTrue(actual.equals(expected));
 		
 	}
 	
@@ -124,7 +125,7 @@ public class DataUtilityTest {
 		ByteBuffer actual = DataUtility.parseValue(schema, value);
 		ByteBuffer expected = ByteBuffer.wrap("Kinesis-Kafka Connector".getBytes());
 		
-		Assert.assertTrue(actual.equals(expected));
+		assertTrue(actual.equals(expected));
 	}
 
 }


### PR DESCRIPTION
### Description:
chaning the way the lib is built. instead of dependent-less + Uber jar, the build artifacts will follow a standard java app output: a jar without dependencies and all dependencies in `target/lib/*` dir.

### Issue Reference URL

#74 

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to Kinesis-Kafka Connector.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a ISSUE associated with this PR?
- [x] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via `mvn clean install` at the project's root folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you added the LICENSE header to new files?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
